### PR TITLE
Feature/no token error

### DIFF
--- a/server/api/spotify.ts
+++ b/server/api/spotify.ts
@@ -18,10 +18,15 @@ export default async () => {
   }
 
   let token: string
+  let returnedError: Error
 
   await requestPromise.post(authOptions, function (error, response, body) {
-    if (error) console.log(error)
-    token = body.access_token
+    if (error) {
+      returnedError = error
+    } else {
+      token = body.access_token
+    }
   })
-  return { token }
+
+  return { token, error: returnedError }
 }

--- a/services/queryService.ts
+++ b/services/queryService.ts
@@ -55,5 +55,5 @@ const _requestAccessToken = async () => {
     .then(result => {
       return result.json()
     })
-    .catch(error => console.log(error))
+    .catch(error => new Error(error))
 }


### PR DESCRIPTION
- Return no_token error from backend
- Return error from spotify search endpoint to the user, so they can at least know there is a problem (in this case affecting to "Invalid token requests"

...Still not the most optimal way (by far), but a working one...